### PR TITLE
Remove deleted file from instrustions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Installation
 ------------
 
 * Clone this repository
-* `./autogen.sh`
+* `autoreconf -ivf`
 * `./configure`
 * `make`
 * Optionally `make install` will put the resulting binary to `/usr/local/bin`


### PR DESCRIPTION
Readme is referencing deleted file. Instead of running missing file, I put the autoreconf command itself.